### PR TITLE
Fixed a bug related to screen brightness changes

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -23,7 +23,7 @@ source=(http://ftp.gnome.org/pub/gnome/sources/$_pkgname/${pkgver%.*}/$_pkgname-
         move-desktop-file.patch)
 sha256sums=('3db993f2dbabc0c9d06a309bb12c9a7104b9cdda414ac4b1c301f5114a441c15'
             '2e7e40175533556493bb58795a2c1b4e53b4baba35d151e632b933c6077456d9'
-            'ddc4dfaa8083ff24a7d2fb6138b8c3fee5d4e6c60c24b4e80a39392d0c8f2162'
+            'c41640f51cc2b0165b94cf39971fabfaed3cd678e24cddb3efecfe1b673fc33f'
             '1b6b8216434b766e1389e876cba5d6ab61498c5824f6d2cc5d67dcf58a07842a'
             '0821f469cd168f3a131da513a5f9dd352c06f9bc31d57d79de4dc063fa2de915'
             '02da2467e287620c3b717c7ff5ffea7403cce714d5aa32e27d051b6571451e2a'

--- a/standalone-media-keys-helper.patch
+++ b/standalone-media-keys-helper.patch
@@ -123,6 +123,24 @@ diff -Naur gnome-settings-daemon-3.6.4.orig/plugins/media-keys/gsd-media-keys-ma
  }
  
  static void
+@@ -1650,7 +1641,7 @@
+                   gpointer             user_data)
+ {
+         GError *error = NULL;
+-        guint percentage;
++        gint32 percentage;
+         GVariant *new_percentage;
+         GsdMediaKeysManager *manager = GSD_MEDIA_KEYS_MANAGER (user_data);
+ 
+@@ -1664,7 +1655,7 @@
+         }
+ 
+         /* update the dialog with the new value */
+-        g_variant_get (new_percentage, "(u)", &percentage);
++        g_variant_get (new_percentage, "(ii)", &percentage, NULL);
+         dialog_init (manager);
+         gsd_osd_window_set_action_custom (GSD_OSD_WINDOW (manager->priv->dialog),
+                                                  "display-brightness-symbolic",
 @@ -2090,7 +2085,6 @@
          char *theme_name;
  


### PR DESCRIPTION
The bar indicating the brightness was always at (more than?) 100%,
because the GVariant was not passed correctly from the DBus call.
Apparently it is not an unsigned int, but a pair of ints of which the
second does not have any meaningful value, if I have observed correctly.
